### PR TITLE
Remove reset dwarves manager to base call after player death

### DIFF
--- a/Objects/Spawners/DwarvesManager/DwarvesManager.gd
+++ b/Objects/Spawners/DwarvesManager/DwarvesManager.gd
@@ -57,9 +57,10 @@ func create_dwarf(DwarfScene, damage:float, hp:float, on_died_func:String):
 	return dwarf
 	
 func on_next_level(level : int):
-	dwarf_max_hp = default_dwarf_hp * pow((HP_INCREASE_RATION + 1),level-1)
-	dwarf_damage = default_dwarf_damage * pow((DAMAGE_INCREASE_RATIO + 1),level-1)
+	dwarf_max_hp = default_dwarf_hp * pow((HP_INCREASE_RATION + 1), level - 1)
+	dwarf_damage = default_dwarf_damage * pow((DAMAGE_INCREASE_RATIO + 1), level - 1)
 
+# Should be used only after revival
 func reset_to_default() -> void:
 	dwarf_max_hp = default_dwarf_hp
 	dwarf_damage = default_dwarf_damage

--- a/Scripts/LevelManager.gd
+++ b/Scripts/LevelManager.gd
@@ -56,7 +56,6 @@ func _ready():
 	var elf = world.get_node("MainObjectsLayer/Elf")
 	elf.connect("game_over", self, "on_Game_Over")
 	connect("next_level", dwarves_manager, "on_next_level")
-	connect("reset_to_base", dwarves_manager, "reset_to_default")
 	connect("reset_to_base", elf, "reset_to_base")
 	connect("reset_to_base", GameData, "on_game_over")
 	GameLoader.connect("save_data_was_loaded", self, "show_offline_screen")


### PR DESCRIPTION
https://trello.com/c/7vcG83y5/700-hp-krasnali-resetuje-si%C4%99-po-%C5%9Bmierci-gracza-do-startowych-warto%C5%9Bci